### PR TITLE
Correct Variable constructor docstring (#3871)

### DIFF
--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -186,9 +186,6 @@ class Variable(object):
         If `None`, either the datatype will be kept (if `initial_value` is
         a Tensor), or `convert_to_tensor` will decide.
 
-    Returns:
-      A Variable.
-
     Raises:
       ValueError: If both `variable_def` and initial_value are specified.
       ValueError: If the initial value is not specified, or does not have a


### PR DESCRIPTION
It's a constructor, so it doesn't return anything. I removed the comment stating that it returns a Variable.